### PR TITLE
Consumer: add redistribute RDY for starved connections

### DIFF
--- a/NsqSharp.Tests/ConfigTest.cs
+++ b/NsqSharp.Tests/ConfigTest.cs
@@ -219,7 +219,7 @@ namespace NsqSharp.Tests
             c.Set("backoff_multiplier", TimeSpan.FromMinutes(60));
             c.Set("max_attempts", 65535);
             c.Set("low_rdy_idle_timeout", TimeSpan.FromMinutes(5));
-            c.Set("rdy_redistribute_interval", TimeSpan.FromMinutes(5));
+            c.Set("rdy_redistribute_interval", TimeSpan.FromSeconds(5));
             c.Set("client_id", "my");
             c.Set("hostname", "my.host.name.com");
             c.Set("user_agent", "user-agent/1.0");
@@ -247,7 +247,7 @@ namespace NsqSharp.Tests
             Assert.AreEqual(TimeSpan.FromMinutes(60), c.BackoffMultiplier, "backoff_multiplier");
             Assert.AreEqual(65535, c.MaxAttempts, "max_attempts");
             Assert.AreEqual(TimeSpan.FromMinutes(5), c.LowRdyIdleTimeout, "low_rdy_idle_timeout");
-            Assert.AreEqual(TimeSpan.FromMinutes(5), c.RDYRedistributeInterval, "rdy_redistribute_interval");
+            Assert.AreEqual(TimeSpan.FromSeconds(5), c.RDYRedistributeInterval, "rdy_redistribute_interval");
             Assert.AreEqual("my", c.ClientID, "client_id");
             Assert.AreEqual("my.host.name.com", c.Hostname, "hostname");
             Assert.AreEqual("user-agent/1.0", c.UserAgent, "user_agent");

--- a/NsqSharp.Tests/ConfigTest.cs
+++ b/NsqSharp.Tests/ConfigTest.cs
@@ -124,6 +124,7 @@ namespace NsqSharp.Tests
             Assert.AreEqual(5, c.MaxAttempts, "max_attempts");
             Assert.AreEqual(TimeSpan.FromSeconds(10), c.LowRdyIdleTimeout, "low_rdy_idle_timeout");
             Assert.AreEqual(TimeSpan.FromSeconds(5), c.RDYRedistributeInterval, "rdy_redistribute_interval");
+            Assert.AreEqual(false, c.RDYRedistributeOnIdle, "rdy_redistribute_on_idle");
             Assert.AreEqual(OS.Hostname().Split('.')[0], c.ClientID, "client_id");
             Assert.AreEqual(OS.Hostname(), c.Hostname, "hostname");
             Assert.AreEqual(string.Format("{0}/{1}", ClientInfo.ClientName, ClientInfo.Version), c.UserAgent, "user_agent");
@@ -218,7 +219,7 @@ namespace NsqSharp.Tests
             c.Set("backoff_multiplier", TimeSpan.FromMinutes(60));
             c.Set("max_attempts", 65535);
             c.Set("low_rdy_idle_timeout", TimeSpan.FromMinutes(5));
-            c.Set("rdy_redistribute_interval", TimeSpan.FromSeconds(5));
+            c.Set("rdy_redistribute_interval", TimeSpan.FromMinutes(5));
             c.Set("client_id", "my");
             c.Set("hostname", "my.host.name.com");
             c.Set("user_agent", "user-agent/1.0");
@@ -246,7 +247,7 @@ namespace NsqSharp.Tests
             Assert.AreEqual(TimeSpan.FromMinutes(60), c.BackoffMultiplier, "backoff_multiplier");
             Assert.AreEqual(65535, c.MaxAttempts, "max_attempts");
             Assert.AreEqual(TimeSpan.FromMinutes(5), c.LowRdyIdleTimeout, "low_rdy_idle_timeout");
-            Assert.AreEqual(TimeSpan.FromSeconds(5), c.RDYRedistributeInterval, "rdy_redistribute_interval");
+            Assert.AreEqual(TimeSpan.FromMinutes(5), c.RDYRedistributeInterval, "rdy_redistribute_interval");
             Assert.AreEqual("my", c.ClientID, "client_id");
             Assert.AreEqual("my.host.name.com", c.Hostname, "hostname");
             Assert.AreEqual("user-agent/1.0", c.UserAgent, "user_agent");
@@ -316,7 +317,7 @@ namespace NsqSharp.Tests
             Assert.Throws<Exception>(() => c.Set("backoff_multiplier", TimeSpan.FromMinutes(60) + tick), "backoff_multiplier");
             Assert.Throws<Exception>(() => c.Set("max_attempts", 65535 + 1), "max_attempts");
             Assert.Throws<Exception>(() => c.Set("low_rdy_idle_timeout", TimeSpan.FromMinutes(5) + tick), "low_rdy_idle_timeout");
-            Assert.Throws<Exception>(() => c.Set("rdy_redistribute_interval", TimeSpan.FromSeconds(5) + tick), "rdy_redistribute_interval");
+            Assert.Throws<Exception>(() => c.Set("rdy_redistribute_interval", TimeSpan.FromMinutes(5) + tick), "rdy_redistribute_interval");
             //Assert.Throws<Exception>(() => c.Set("client_id", "my"), "client_id");
             //Assert.Throws<Exception>(() => c.Set("hostname", "my.host.name.com"), "hostname");
             //Assert.Throws<Exception>(() => c.Set("user_agent", "user-agent/1.0"), "user_agent");
@@ -359,6 +360,7 @@ namespace NsqSharp.Tests
             c.Set("heartbeat_interval", "2s");
             c.Set("rdy_redistribute_interval", "3s");
             c.Set("backoff_strategy", backoffStrategy);
+            c.Set("rdy_redistribute_on_idle", true);
             c.Validate();
 
             var c2 = c.Clone();
@@ -376,6 +378,7 @@ namespace NsqSharp.Tests
             Assert.AreEqual(5, c2.MaxAttempts, "max_attempts");
             Assert.AreEqual(TimeSpan.FromSeconds(10), c2.LowRdyIdleTimeout, "low_rdy_idle_timeout");
             Assert.AreEqual(TimeSpan.FromSeconds(3), c2.RDYRedistributeInterval, "rdy_redistribute_interval");
+            Assert.AreEqual(true, c2.RDYRedistributeOnIdle, "rdy_redistribute_on_idle");
             Assert.AreEqual(OS.Hostname().Split('.')[0], c2.ClientID, "client_id");
             Assert.AreEqual(OS.Hostname(), c2.Hostname, "hostname");
             Assert.AreEqual(string.Format("{0}/{1}", ClientInfo.ClientName, ClientInfo.Version), c2.UserAgent, "user_agent");

--- a/NsqSharp.Tests/ConsumerRdyRedistributionTest.cs
+++ b/NsqSharp.Tests/ConsumerRdyRedistributionTest.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using NsqSharp.Api;
+using NsqSharp.Core;
+using NsqSharp.Tests.Utils.Extensions;
+using NsqSharp.Utils.Extensions;
+using NsqSharp.Utils.Loggers;
+using NUnit.Framework;
+
+namespace NsqSharp.Tests
+{
+#if !RUN_INTEGRATION_TESTS
+    [TestFixture(IgnoreReason = "NSQD Integration Test")]
+#else
+    [TestFixture]
+#endif
+    public class ConsumerRdyRedistributionTest
+    {
+        private static readonly NsqdHttpClient _nsqdHttpClient1;
+        private static readonly NsqdHttpClient _nsqdHttpClient2;
+        private static readonly NsqLookupdHttpClient _nsqLookupdHttpClient;
+
+        static ConsumerRdyRedistributionTest()
+        {
+            _nsqdHttpClient1 = new NsqdHttpClient("127.0.0.1:4151", TimeSpan.FromSeconds(5));
+            _nsqdHttpClient2 = new NsqdHttpClient("127.0.0.1:5151", TimeSpan.FromSeconds(5));
+            _nsqLookupdHttpClient = new NsqLookupdHttpClient("127.0.0.1:4161", TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        [Ignore("Long Running Test")]
+        public void TestRdyRedistribution()
+        {
+            var results = TestRdyRedistribution(
+                rdyRedistributeOnIdle: true,
+                maxInFlight: 4,
+                rdyRedistributeInterval: TimeSpan.FromSeconds(5),
+                lowRdyIdleTimeout: TimeSpan.FromMinutes(5),
+                handlerSleepTime: TimeSpan.FromSeconds(10),
+                sleepBeforeIdlePublish: TimeSpan.FromMinutes(12),
+                testDuration: TimeSpan.FromMinutes(30),
+                startWithInitialMessageOnIdleNsqd: true,
+                numberOfMessagesToSendOnIdleNsqd: 2
+            );
+
+            // expected max without redistribute: 360+3
+            // ideal: 720 - ((5*12)*2) + 3 = 603
+            // actual: 600
+
+            foreach (var item in results)
+            {
+                Console.WriteLine("[{0}] {1} {2}", item.HandlerStartTime.Formatted(), item.NsqdAddress, item.Message);
+            }
+        }
+
+        private static List<TestResults> TestRdyRedistribution(
+            bool rdyRedistributeOnIdle,
+            int maxInFlight,
+            TimeSpan rdyRedistributeInterval,
+            TimeSpan lowRdyIdleTimeout,
+            TimeSpan handlerSleepTime,
+            TimeSpan sleepBeforeIdlePublish,
+            TimeSpan testDuration,
+            bool startWithInitialMessageOnIdleNsqd,
+            int numberOfMessagesToSendOnIdleNsqd
+        )
+        {
+            string topicName = string.Format("test_rdy_redistribution_{0}", DateTime.Now.UnixNano());
+
+            try
+            {
+                _nsqdHttpClient1.CreateTopic(topicName);
+                _nsqdHttpClient2.CreateTopic(topicName);
+                _nsqLookupdHttpClient.CreateTopic(topicName);
+
+                Producer p1 = new Producer("127.0.0.1:4150");
+                if (startWithInitialMessageOnIdleNsqd)
+                {
+                    p1.Publish(topicName, "initial");
+                }
+
+                Producer p2 = new Producer("127.0.0.1:5150");
+                for (int i = 0; i < 10000; i++)
+                {
+                    p2.Publish(topicName, i.ToString());
+                }
+
+                Consumer c = new Consumer(
+                    topicName,
+                    "test-channel",
+                    new TestConsoleLogger(),
+                    new Config
+                    {
+                        MaxInFlight = maxInFlight,
+                        LowRdyIdleTimeout = lowRdyIdleTimeout,
+                        RDYRedistributeInterval = rdyRedistributeInterval,
+                        RDYRedistributeOnIdle = rdyRedistributeOnIdle
+                    }
+                );
+                var messageHandler = new MessageHandler(handlerSleepTime);
+                c.AddHandler(messageHandler, threads: maxInFlight);
+                c.ConnectToNsqLookupd("127.0.0.1:4161");
+
+                Thread.Sleep(sleepBeforeIdlePublish);
+
+                for (int i = 1; i <= numberOfMessagesToSendOnIdleNsqd; i++)
+                {
+                    p1.Publish(topicName, string.Format("{0} - snuck in!", i));
+                }
+
+                Thread.Sleep(testDuration - sleepBeforeIdlePublish);
+
+                p1.Stop();
+                p2.Stop();
+
+                c.Stop();
+
+                return messageHandler.GetTestResults();
+            }
+            finally
+            {
+                _nsqdHttpClient1.DeleteTopic(topicName);
+                _nsqdHttpClient2.DeleteTopic(topicName);
+                _nsqLookupdHttpClient.DeleteTopic(topicName);
+            }
+        }
+
+        public class TestConsoleLogger : ILogger
+        {
+            /// <summary>
+            /// Writes the output for a logging event.
+            /// </summary>
+            public void Output(LogLevel logLevel, string message)
+            {
+                Console.WriteLine("[{0}] {1}", logLevel, message);
+            }
+
+            public void Flush()
+            {
+            }
+        }
+
+        public class MessageHandler : IHandler
+        {
+            private readonly TimeSpan _sleepTime;
+            private readonly List<TestResults> _testResults;
+            private readonly object _testResultsLocker = new object();
+
+            public MessageHandler(TimeSpan sleepTime)
+            {
+                _sleepTime = sleepTime;
+                _testResults = new List<TestResults>();
+            }
+
+            public void HandleMessage(IMessage message)
+            {
+                var startTime = DateTime.Now;
+                string body = Encoding.UTF8.GetString(message.Body);
+
+                Console.WriteLine("[{0}] {1} {2}", startTime.Formatted(), message.NsqdAddress, body);
+
+                lock (_testResultsLocker)
+                {
+                    _testResults.Add(new TestResults
+                    {
+                        HandlerStartTime = startTime,
+                        NsqdAddress = message.NsqdAddress,
+                        Message = body
+                    });
+                }
+
+                Thread.Sleep(_sleepTime);
+            }
+
+            public void LogFailedMessage(IMessage message)
+            {
+            }
+
+            public List<TestResults> GetTestResults()
+            {
+                return _testResults;
+            }
+        }
+
+        [DebuggerDisplay("{HandlerStartTime} {NsqdAddress} {Message}")]
+        public class TestResults
+        {
+            public DateTime HandlerStartTime { get; set; }
+            public string NsqdAddress { get; set; }
+            public string Message { get; set; }
+        }
+    }
+}

--- a/NsqSharp.Tests/MockTest.cs
+++ b/NsqSharp.Tests/MockTest.cs
@@ -27,6 +27,9 @@ namespace NsqSharp.Tests
             }
         }
 
+#if !RUN_INTEGRATION_TESTS
+        [Ignore("NSQD Integration Test")]
+#endif
         [Test]
         public void TestConsumerBackoff()
         {
@@ -172,6 +175,9 @@ namespace NsqSharp.Tests
             Assert.AreEqual(expected, actual);
         }
 
+#if !RUN_INTEGRATION_TESTS
+        [Ignore("NSQD Integration Test")]
+#endif
         [Test]
         public void TestConsumerBackoffDisconnect()
         {

--- a/NsqSharp.Tests/NsqSharp.Tests.csproj
+++ b/NsqSharp.Tests/NsqSharp.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Bus\TestFakes\MessageAuditorStub.cs" />
     <Compile Include="Bus\TouchTest.cs" />
     <Compile Include="Bus\Utils\InterfaceBuilderTest.cs" />
+    <Compile Include="ConsumerRdyRedistributionTest.cs" />
     <Compile Include="Utils\Channels\ChanTest.cs" />
     <Compile Include="Core\CommandTest.cs" />
     <Compile Include="ConfigTest.cs" />

--- a/NsqSharp/Config.cs
+++ b/NsqSharp/Config.cs
@@ -188,9 +188,9 @@ namespace NsqSharp
 
         /// <summary>
         /// Duration between redistributing max-in-flight to connections.
-        /// Range: 1ms-5m Default: 5s
+        /// Range: 1ms-5s Default: 5s
         /// </summary>
-        [Opt("rdy_redistribute_interval"), Min("1ms"), Max("5m"), Default("5s")]
+        [Opt("rdy_redistribute_interval"), Min("1ms"), Max("5s"), Default("5s")]
         public TimeSpan RDYRedistributeInterval { get; set; }
 
         /// <summary>

--- a/NsqSharp/Config.cs
+++ b/NsqSharp/Config.cs
@@ -188,10 +188,17 @@ namespace NsqSharp
 
         /// <summary>
         /// Duration between redistributing max-in-flight to connections.
-        /// Range: 1ms-5s Default: 5s
+        /// Range: 1ms-5m Default: 5s
         /// </summary>
-        [Opt("rdy_redistribute_interval"), Min("1ms"), Max("5s"), Default("5s")]
+        [Opt("rdy_redistribute_interval"), Min("1ms"), Max("5m"), Default("5s")]
         public TimeSpan RDYRedistributeInterval { get; set; }
+
+        /// <summary>
+        /// Redistribute RDY counts to active nsqd instances when others are idle.
+        /// Default: <c>false</c>
+        /// </summary>
+        [Opt("rdy_redistribute_on_idle"), Default(false)]
+        public bool RDYRedistributeOnIdle { get; set; }
 
         /// <summary>ClientID identifier sent to nsqd representing this client.
         /// Default: short hostname.</summary>

--- a/NsqSharp/Utils/Extensions/DateTimeExtensions.cs
+++ b/NsqSharp/Utils/Extensions/DateTimeExtensions.cs
@@ -7,7 +7,7 @@ namespace NsqSharp.Utils.Extensions
     /// </summary>
     public static class DateTimeExtensions
     {
-        private static readonly DateTime _epoch = new DateTime(1970, 1, 1);
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary>
         /// UnixNano returns t as a Unix time, the number of nanoseconds elapsed since January 1, 1970 UTC. The result is

--- a/NsqSharp/Utils/Time.cs
+++ b/NsqSharp/Utils/Time.cs
@@ -14,6 +14,8 @@ namespace NsqSharp.Utils
     /// </summary>
     public static class Time
     {
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         /// <summary>Nanosecond</summary>
         public const long Nanosecond = 1;
         /// <summary>Microsecond</summary>
@@ -120,7 +122,7 @@ namespace NsqSharp.Utils
         public static DateTime Unix(long sec, long nsec)
         {
             long ticks = sec * Second / 100 + nsec / 100;
-            return new DateTime(ticks, DateTimeKind.Local);
+            return _epoch.AddTicks(ticks);
         }
 
         /// <summary>


### PR DESCRIPTION
(ignore the AppVeyor check below)

Scenario:

Say you have 2 nsqd instances, one has 100k messages on a topic and the other has 0. The Consumer's MaxInFlight is >= 2.

This method is meant to redistribute the RDY count to nsqd instances with messages when one or more nsqd instances are idle, periodically giving RDY back to the idle connections to check for new messages.

We have to avoid getting a connection stuck with a RDY count of 0. I think this is covered but would like someone else to take a look.

One thing I'm worried about is if all RDY's are given to the active connections it may use them until the topic drains before yielding to another (previously idle) connection. In an eventually consistent system this might not be a problem but it would be concerning to see a RDY count of 0 and In Flight count of 0 on an instance with messages in the queue.
