### PR TITLE
Fix issues when nsqd connectivity lost

### DIFF
--- a/Examples/PointOfSale/PointOfSale.Common/PointOfSale.Common.csproj
+++ b/Examples/PointOfSale/PointOfSale.Common/PointOfSale.Common.csproj
@@ -83,16 +83,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="appSettings.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="connectionStrings.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="diagnostics.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="nlog.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup />

--- a/Examples/PointOfSale/PointOfSale.Common/appSettings.config
+++ b/Examples/PointOfSale/PointOfSale.Common/appSettings.config
@@ -3,7 +3,7 @@
   <!-- set to true to use sql for message auditing -->
   <add key="UseSql" value="false"/>
   <!-- set to true to cache service call responses -->
-  <add key="UseServiceCallCache" value="true"/>
+  <add key="UseServiceCallCache" value="false"/>
   <!-- set nemesis to make a percent of service calls fail (integer value, 0-100) -->
   <add key="Nemesis" value="0"/>
 

--- a/NsqSharp.Tests/Bus/BusShutdownTest.cs
+++ b/NsqSharp.Tests/Bus/BusShutdownTest.cs
@@ -79,7 +79,7 @@ namespace NsqSharp.Tests.Bus
                                BusService.Stop();
                                Console.WriteLine(string.Format("Shutdown occurred in {0}", DateTime.Now - start));
                                stoppedChan.Send(true);
-                           });
+                           }, "bus stopper and stopped notifier");
 
                 bool timeout = false;
                 Select

--- a/NsqSharp.Tests/Bus/BusShutdownTest.cs
+++ b/NsqSharp.Tests/Bus/BusShutdownTest.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Newtonsoft.Json;
+using NsqSharp.Api;
+using NsqSharp.Bus;
+using NsqSharp.Bus.Configuration;
+using NsqSharp.Bus.Configuration.BuiltIn;
+using NsqSharp.Tests.Bus.TestFakes;
+using NsqSharp.Utils;
+using NsqSharp.Utils.Channels;
+using NsqSharp.Utils.Extensions;
+using NUnit.Framework;
+using StructureMap;
+
+namespace NsqSharp.Tests.Bus
+{
+#if !RUN_INTEGRATION_TESTS
+    [TestFixture(IgnoreReason = "NSQD Integration Test")]
+#else
+    [TestFixture]
+#endif
+    public class BusShutdownTest
+    {
+        private static readonly NsqdHttpClient _nsqdHttpClient;
+        private static readonly NsqLookupdHttpClient _nsqLookupdHttpClient;
+
+        private static readonly WaitGroup _wg = new WaitGroup();
+        private static bool _handlerFinished;
+
+        static BusShutdownTest()
+        {
+            _nsqdHttpClient = new NsqdHttpClient("http://127.0.0.1:4151", TimeSpan.FromSeconds(5));
+            _nsqLookupdHttpClient = new NsqLookupdHttpClient("http://127.0.0.1:4161", TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public void TestBusShutdown()
+        {
+            string topicName = string.Format("test_currentmessage_{0}", DateTime.Now.UnixNano());
+            const string channelName = "test_currentmessage";
+
+            var container = new Container();
+
+            _nsqdHttpClient.CreateTopic(topicName);
+            _nsqLookupdHttpClient.CreateTopic(topicName);
+
+            try
+            {
+                BusService.Start(new BusConfiguration(
+                    new StructureMapObjectBuilder(container),
+                    new NewtonsoftJsonSerializer(typeof(JsonConverter).Assembly),
+                    new MessageAuditorStub(),
+                    new MessageTypeToTopicDictionary(new Dictionary<Type, string> {
+                        { typeof(TestMessage), topicName }
+                    }),
+                    new HandlerTypeToChannelDictionary(new Dictionary<Type, string> {
+                        { typeof(TestMessageHandler), channelName }
+                    }),
+                    defaultNsqLookupdHttpEndpoints: new[] { "127.0.0.1:4161" },
+                    defaultThreadsPerHandler: 1,
+                    nsqConfig: new Config
+                    {
+                        LookupdPollJitter = 0,
+                        LookupdPollInterval = TimeSpan.FromSeconds(1)
+                    }
+                ));
+
+                var bus = container.GetInstance<IBus>();
+
+                _wg.Add(1);
+                bus.Send(new TestMessage());
+                _wg.Wait();
+
+                var stoppedChan = new Chan<bool>(1);
+                GoFunc.Run(() =>
+                           {
+                               var start = DateTime.Now;
+                               BusService.Stop();
+                               Console.WriteLine(string.Format("Shutdown occurred in {0}", DateTime.Now - start));
+                               stoppedChan.Send(true);
+                           });
+
+                bool timeout = false;
+                Select
+                    .CaseReceive(stoppedChan, o => { })
+                    .CaseReceive(Time.After(TimeSpan.FromMilliseconds(90000)), o => { timeout = true; })
+                    .NoDefault();
+
+                Assert.IsFalse(timeout, "timeout");
+                Assert.IsFalse(_handlerFinished, "handlerFinished");
+            }
+            finally
+            {
+                _nsqdHttpClient.DeleteTopic(topicName);
+                _nsqLookupdHttpClient.DeleteTopic(topicName);
+            }
+        }
+
+        private class TestMessage
+        {
+        }
+
+        private class TestMessageHandler : IHandleMessages<TestMessage>
+        {
+            public void Handle(TestMessage message)
+            {
+                _wg.Done();
+                Thread.Sleep(-1);
+                _handlerFinished = true;
+            }
+        }
+    }
+}

--- a/NsqSharp.Tests/Bus/BusShutdownTest.cs
+++ b/NsqSharp.Tests/Bus/BusShutdownTest.cs
@@ -37,8 +37,8 @@ namespace NsqSharp.Tests.Bus
         [Test]
         public void TestBusShutdown()
         {
-            string topicName = string.Format("test_currentmessage_{0}", DateTime.Now.UnixNano());
-            const string channelName = "test_currentmessage";
+            string topicName = string.Format("test_busshutdown_{0}", DateTime.Now.UnixNano());
+            const string channelName = "test_busshutdown";
 
             var container = new Container();
 

--- a/NsqSharp.Tests/ConsumerTest.cs
+++ b/NsqSharp.Tests/ConsumerTest.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization.Json;
 using System.Text;
 using NsqSharp.Api;
 using NsqSharp.Core;
+using NsqSharp.Utils;
 using NsqSharp.Utils.Extensions;
 using NUnit.Framework;
 
@@ -33,16 +34,24 @@ namespace NsqSharp.Tests
             consumerTest(configSetter: null);
         }
 
-        // TODO: TLS
-        /*[Test, Ignore("TLS not implemented")]
+        [Test]
         public void TestConsumerTLS()
         {
             consumerTest(c =>
                          {
-                             c.TlsV1 = true;
                              c.TlsConfig = new TlsConfig { InsecureSkipVerify = true };
                          });
-        }*/
+        }
+
+        [Test]
+        public void TestConsumerTLSViaSet()
+        {
+            consumerTest(c =>
+                         {
+                             c.Set("tls_insecure_skip_verify", true);
+                         });
+        }
+
 
         // TODO: Deflate
         /*[Test, Ignore("Deflate not implemented")]
@@ -88,28 +97,27 @@ namespace NsqSharp.Tests
             });
         }*/
 
-        // TODO: TLS
-        /*[Test, Ignore("TLS Client Cert not implemented")]
+        /*
+        // TODO: Address when client certificate auth enabled
+        [Test]
         public void TestConsumerTLSClientCert()
         {
-            //cert, _ := tls.LoadX509KeyPair("./test/client.pem", "./test/client.key") // TODO
             consumerTest(c =>
             {
-                c.TlsV1 = true;
                 c.TlsConfig = new TlsConfig
                 {
-                    //Certificates = cert // TODO
+                    //Certificates = cert
                     InsecureSkipVerify = true
                 };
             });
-        }*/
+        }
 
-        // TODO: TLS
-        /*[Test, Ignore("TLS Client Cert not implemented")]
+        // TODO: Address when client certificate auth enabled
+        [Test]
         public void TestConsumerTLSClientCertViaSet()
         {
             consumerTest(c =>
-            {
+            {                
                 c.Set("ts_v1", true);
                 c.Set("tls_cert", "./test/client.pem");
                 c.Set("tls_key", "./test/client.key");
@@ -134,10 +142,10 @@ namespace NsqSharp.Tests
             /*if (config.Deflate)
                 topicName = topicName + "_deflate";
             else if (config.Snappy)
-                topicName = topicName + "_snappy";
-            
-            if (config.TlsV1)
-                topicName = topicName + "_tls";*/
+                topicName = topicName + "_snappy";*/
+
+            if (config.TlsConfig != null)
+                topicName = topicName + "_tls";
 
             topicName = topicName + DateTime.Now.Unix();
 

--- a/NsqSharp.Tests/NsqSharp.Tests.csproj
+++ b/NsqSharp.Tests/NsqSharp.Tests.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Bus\AutofacBusTest.cs" />
     <Compile Include="Bus\BusCurrentMessageTest.cs" />
+    <Compile Include="Bus\BusShutdownTest.cs" />
     <Compile Include="Bus\CurrentThreadMessageMockableTest.cs" />
     <Compile Include="Bus\DeferTest.cs" />
     <Compile Include="Bus\MessageMutatorTest.cs" />
@@ -103,6 +104,7 @@
     <Compile Include="Utils\Extensions\PropertyInfoExtensionsTest.cs" />
     <Compile Include="Utils\Extensions\RNGCryptoServiceProviderExtensionsTest.cs" />
     <Compile Include="Utils\SliceTest.cs" />
+    <Compile Include="Utils\TickerTest.cs" />
     <Compile Include="Utils\TimeTest.cs" />
     <Compile Include="MockTest.cs" />
     <Compile Include="ProducerBenchmarkTest.cs" />

--- a/NsqSharp.Tests/ProducerBenchmarkTest.cs
+++ b/NsqSharp.Tests/ProducerBenchmarkTest.cs
@@ -111,7 +111,7 @@ namespace NsqSharp.Tests
                 startCh.Close();
 
                 var done = new Chan<bool>();
-                GoFunc.Run(() => { wg.Wait(); done.Send(true); });
+                GoFunc.Run(() => { wg.Wait(); done.Send(true); }, "waiter and done sender");
 
                 bool finished = false;
                 Select

--- a/NsqSharp.Tests/Utils/Channels/ChanTest.cs
+++ b/NsqSharp.Tests/Utils/Channels/ChanTest.cs
@@ -408,7 +408,7 @@ namespace NsqSharp.Tests.Utils.Channels
                     .NoDefault();
 
                 wg.Done();
-            });
+            }, "sender");
 
             GoFunc.Run(() =>
             {
@@ -417,7 +417,7 @@ namespace NsqSharp.Tests.Utils.Channels
                     .NoDefault();
 
                 wg.Done();
-            });
+            }, "receiver");
 
             wg.Wait();
 
@@ -710,8 +710,8 @@ namespace NsqSharp.Tests.Utils.Channels
 
             for (int i = 0; i < 8; i++)
             {
-                GoFunc.Run(receive);
-                GoFunc.Run(send);
+                GoFunc.Run(receive, "receiver");
+                GoFunc.Run(send, "sender");
             }
 
             start.Close();
@@ -788,8 +788,8 @@ namespace NsqSharp.Tests.Utils.Channels
 
             for (int i = 0; i < 8; i++)
             {
-                GoFunc.Run(receive);
-                GoFunc.Run(send);
+                GoFunc.Run(receive, "receiver");
+                GoFunc.Run(send, "sender");
             }
 
             start.Close();

--- a/NsqSharp.Tests/Utils/TickerTest.cs
+++ b/NsqSharp.Tests/Utils/TickerTest.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using NsqSharp.Utils;
+using NsqSharp.Utils.Channels;
+using NUnit.Framework;
+
+namespace NsqSharp.Tests.Utils
+{
+    [TestFixture]
+    public class TickerTest
+    {
+        [Test]
+        public void TestSingleTicker()
+        {
+            // arrange
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            // act
+            bool ok;
+            var sentAt = (DateTime)ticker.C.ReceiveOk(out ok);
+            var duration = DateTime.Now - start;
+            var offBy = DateTime.Now - sentAt;
+
+            ticker.Stop();
+
+            // assert
+            Assert.IsTrue(ok, "ok");
+            Assert.GreaterOrEqual(duration, TimeSpan.FromSeconds(1), "duration");
+            Assert.Less(duration, TimeSpan.FromSeconds(1.5), "duration");
+            Assert.Less(offBy, TimeSpan.FromSeconds(0.5), "offBy");
+        }
+
+        [Test]
+        public void TestDoubleTicker()
+        {
+            // arrange
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            // act
+            bool ok1;
+            var sentAt1 = (DateTime)ticker.C.ReceiveOk(out ok1);
+            var duration1 = DateTime.Now - start;
+            var offBy1 = DateTime.Now - sentAt1;
+
+            bool ok2;
+            var sentAt2 = (DateTime)ticker.C.ReceiveOk(out ok2);
+            var duration2 = DateTime.Now - start;
+            var offBy2 = DateTime.Now - sentAt2;
+
+            ticker.Stop();
+
+            // assert
+            Assert.IsTrue(ok1, "ok1");
+            Assert.GreaterOrEqual(duration1, TimeSpan.FromSeconds(1), "duration1");
+            Assert.Less(duration1, TimeSpan.FromSeconds(1.5), "duration1");
+            Assert.Less(offBy1, TimeSpan.FromSeconds(0.5), "offBy1");
+
+            Assert.IsTrue(ok2, "ok2");
+            Assert.GreaterOrEqual(duration2, TimeSpan.FromSeconds(2), "duration2");
+            Assert.Less(duration2, TimeSpan.FromSeconds(2.5), "duration2");
+            Assert.Less(offBy2, TimeSpan.FromSeconds(0.5), "offBy2");
+        }
+
+        [Test]
+        public void TestDoubleTickerWithStop()
+        {
+            // arrange
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            // act
+            bool ok1;
+            var sentAt1 = (DateTime)ticker.C.ReceiveOk(out ok1);
+            var duration1 = DateTime.Now - start;
+            var offBy1 = DateTime.Now - sentAt1;
+
+            ticker.Stop();
+
+            var newTicker = new Ticker(TimeSpan.FromSeconds(5));
+            bool? ok2 = null;
+            Select
+                .CaseReceiveOk(ticker.C, (d, b) => ok2 = false)
+                .CaseReceive(newTicker.C, _ => ok2 = true)
+                .NoDefault();
+
+            newTicker.Stop();
+
+            // assert
+            Assert.IsTrue(ok1, "ok1");
+            Assert.GreaterOrEqual(duration1, TimeSpan.FromSeconds(1), "duration1");
+            Assert.Less(duration1, TimeSpan.FromSeconds(1.5), "duration1");
+            Assert.Less(offBy1, TimeSpan.FromSeconds(0.5), "offBy1");
+
+            Assert.IsNotNull(ok2, "ok2");
+            Assert.IsTrue(ok2.Value, "ok2");
+        }
+
+        [Test]
+        public void TestTickerLoopWithExitChan()
+        {
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            var listOfTimes = new List<TimeSpan>();
+            var exitChan = new Chan<bool>();
+            var lookupdRecheckChan = new Chan<bool>();
+            bool doLoop = true;
+            using (var select =
+                    Select
+                        .CaseReceive(ticker.C, o => listOfTimes.Add(DateTime.Now - start))
+                        .CaseReceive(lookupdRecheckChan, o => listOfTimes.Add(DateTime.Now - start))
+                        .CaseReceive(exitChan, o => doLoop = false)
+                        .NoDefault(defer: true))
+            {
+                // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
+                while (doLoop)
+                {
+                    select.Execute();
+                    if (listOfTimes.Count >= 10)
+                    {
+                        GoFunc.Run(() => exitChan.Send(true));
+                    }
+                }
+            }
+
+            ticker.Stop();
+
+            var duration = DateTime.Now - start;
+            Assert.AreEqual(10, listOfTimes.Count, "listOfTimes.Count");
+            Assert.GreaterOrEqual(duration, TimeSpan.FromSeconds(10), "duration");
+            Assert.Less(duration, TimeSpan.FromSeconds(11));
+        }
+
+        [Test]
+        public void TestTickerLoopWithNemesisChan()
+        {
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            var listOfTimes = new List<TimeSpan>();
+            var exitChan = new Chan<bool>();
+            var lookupdRecheckChan = new Chan<bool>();
+            bool doLoop = true;
+            using (var select =
+                    Select
+                        .CaseReceive(ticker.C,
+                                     o =>
+                                     {
+                                         Console.WriteLine("Received tick");
+                                         listOfTimes.Add(DateTime.Now - start);
+
+                                         if (listOfTimes.Count == 5)
+                                         {
+                                             GoFunc.Run(() => lookupdRecheckChan.Send(true));
+                                         }
+                                     })
+                        .CaseReceive(lookupdRecheckChan,
+                                     o =>
+                                     {
+                                         Console.WriteLine("Nemesis");
+                                         Thread.Sleep(5000);
+                                     })
+                        .CaseReceive(exitChan, o => doLoop = false)
+                        .NoDefault(defer: true))
+            {
+                // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
+                while (doLoop)
+                {
+                    select.Execute();
+                    if (listOfTimes.Count >= 10)
+                    {
+                        GoFunc.Run(() => exitChan.Send(true));
+                    }
+                }
+            }
+
+            ticker.Stop();
+
+            var duration = DateTime.Now - start;
+            Console.WriteLine(duration);
+            Assert.AreEqual(10, listOfTimes.Count, "listOfTimes.Count");
+            Assert.GreaterOrEqual(duration, TimeSpan.FromSeconds(14), "duration");
+            Assert.Less(duration, TimeSpan.FromSeconds(17));
+        }
+
+        [Test]
+        public void TestTickerLoopWithNemesisBufferedChan()
+        {
+            var start = DateTime.Now;
+            var ticker = new Ticker(TimeSpan.FromSeconds(1));
+
+            int x = 0;
+            var listOfTimes = new List<TimeSpan>();
+            var exitChan = new Chan<bool>();
+            var lookupdRecheckChan = new Chan<bool>(bufferSize: 1);
+            bool doLoop = true;
+            using (var select =
+                    Select
+                        .CaseReceive(ticker.C,
+                                     o =>
+                                     {
+                                         Console.WriteLine("Received tick");
+                                         listOfTimes.Add(DateTime.Now - start);
+
+                                         if (listOfTimes.Count == 5)
+                                         {
+                                             Select
+                                                 .CaseSend(lookupdRecheckChan, true)
+                                                 .NoDefault(defer: false);
+                                         }
+                                     })
+                        .CaseReceive(lookupdRecheckChan,
+                                     o =>
+                                     {
+                                         Console.WriteLine("Nemesis");
+                                         for (int i = 0; i < 5; i++)
+                                         {
+                                             Thread.Sleep(1000);
+                                             Console.Write(".");
+                                         }
+                                         Console.WriteLine();
+                                     })
+                        .CaseReceive(exitChan, o => doLoop = false)
+                        .NoDefault(defer: true))
+            {
+                // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
+                while (doLoop)
+                {
+                    Console.WriteLine("start {0}", x);
+                    if (x == 7)
+                    {
+                        Console.WriteLine("pause");
+                    }
+                    select.Execute();
+                    Console.WriteLine("finish {0}", x);
+                    x++;
+                    if (listOfTimes.Count >= 10)
+                    {
+                        GoFunc.Run(() => exitChan.Send(true));
+                    }
+                }
+            }
+
+            ticker.Stop();
+
+            var duration = DateTime.Now - start;
+            Console.WriteLine(duration);
+            Assert.AreEqual(10, listOfTimes.Count, "listOfTimes.Count");
+            Assert.GreaterOrEqual(duration, TimeSpan.FromSeconds(14), "duration");
+            Assert.Less(duration, TimeSpan.FromSeconds(17));
+        }
+    }
+}

--- a/NsqSharp.Tests/Utils/TickerTest.cs
+++ b/NsqSharp.Tests/Utils/TickerTest.cs
@@ -121,7 +121,7 @@ namespace NsqSharp.Tests.Utils
                     select.Execute();
                     if (listOfTimes.Count >= 10)
                     {
-                        GoFunc.Run(() => exitChan.Send(true));
+                        GoFunc.Run(() => exitChan.Send(true), "exit notifier");
                     }
                 }
             }
@@ -154,7 +154,7 @@ namespace NsqSharp.Tests.Utils
 
                                          if (listOfTimes.Count == 5)
                                          {
-                                             GoFunc.Run(() => lookupdRecheckChan.Send(true));
+                                             GoFunc.Run(() => lookupdRecheckChan.Send(true), "lookupd recheck sender");
                                          }
                                      })
                         .CaseReceive(lookupdRecheckChan,
@@ -172,7 +172,7 @@ namespace NsqSharp.Tests.Utils
                     select.Execute();
                     if (listOfTimes.Count >= 10)
                     {
-                        GoFunc.Run(() => exitChan.Send(true));
+                        GoFunc.Run(() => exitChan.Send(true), "exit notifier");
                     }
                 }
             }
@@ -239,7 +239,7 @@ namespace NsqSharp.Tests.Utils
                     x++;
                     if (listOfTimes.Count >= 10)
                     {
-                        GoFunc.Run(() => exitChan.Send(true));
+                        GoFunc.Run(() => exitChan.Send(true), "exit notifier");
                     }
                 }
             }

--- a/NsqSharp/Core/Conn.cs
+++ b/NsqSharp/Core/Conn.cs
@@ -224,7 +224,7 @@ namespace NsqSharp.Core
             _closeFlag = 1;
             if (_conn != null && _messagesInFlight == 0)
             {
-                _conn.CloseRead();
+                _conn.Close();
             }
         }
 
@@ -759,7 +759,7 @@ namespace NsqSharp.Core
             {
                 log(LogLevel.Info, "beginning close");
                 _exitChan.Close();
-                _conn.CloseRead();
+                _conn.Close();
 
                 _wg.Add(1);
                 GoFunc.Run(cleanup, "Conn:cleanup");
@@ -822,7 +822,7 @@ namespace NsqSharp.Core
         private void waitForCleanup()
         {
             _wg.Wait();
-            _conn.CloseWrite();
+            _conn.Close();
             log(LogLevel.Info, "clean close complete");
             _delegate.OnClose(this);
         }

--- a/NsqSharp/Core/Conn.cs
+++ b/NsqSharp/Core/Conn.cs
@@ -84,7 +84,6 @@ namespace NsqSharp.Core
         private readonly Config _config;
 
         private ITcpConn _conn;
-        // TODO: tlsConn
         private readonly string _addr;
 
         private readonly IConnDelegate _delegate;

--- a/NsqSharp/Producer.cs
+++ b/NsqSharp/Producer.cs
@@ -520,7 +520,6 @@ namespace NsqSharp
                         }
                         // give the runtime a chance to schedule other racing goroutines
                         Thread.Sleep(TimeSpan.FromMilliseconds(5));
-                        // TODO: create PR in go-nsq: is continue necessary in default case?
                     });
             }
         }

--- a/NsqSharp/Producer.cs
+++ b/NsqSharp/Producer.cs
@@ -136,7 +136,9 @@ namespace NsqSharp
         /// Initializes a new instance of the Producer class.
         /// </summary>
         /// <param name="nsqdAddress">The nsqd address.</param>
-        /// <param name="logger">The logger.</param>
+        /// <param name="logger">
+        /// The logger. Default = <see cref="ConsoleLogger"/>(<see cref="E:LogLevel.Info"/>).
+        /// </param>
         public Producer(string nsqdAddress, ILogger logger)
             : this(nsqdAddress, logger, new Config(), null)
         {
@@ -146,7 +148,9 @@ namespace NsqSharp
         /// Initializes a new instance of the Producer class.
         /// </summary>
         /// <param name="nsqdAddress">The nsqd address.</param>
-        /// <param name="logger">The logger.</param>
+        /// <param name="logger">
+        /// The logger. Default = <see cref="ConsoleLogger"/>(<see cref="E:LogLevel.Info"/>).
+        /// </param>
         /// <param name="config">The config. Values are copied, changing the properties on <paramref name="config"/>
         /// after the constructor is called will have no effect on the <see cref="Producer"/>.</param>
         public Producer(string nsqdAddress, ILogger logger, Config config)

--- a/NsqSharp/Utils/Channels/Chan.cs
+++ b/NsqSharp/Utils/Channels/Chan.cs
@@ -167,7 +167,9 @@ namespace NsqSharp.Utils.Channels
                     if (_buffer.Count > 0)
                     {
                         ok = true;
-                        return Dequeue();
+                        data = Dequeue();
+                        _isReadyToSend = (_buffer.Count > 0);
+                        return data;
                     }
                 }
 

--- a/NsqSharp/Utils/GoFunc.cs
+++ b/NsqSharp/Utils/GoFunc.cs
@@ -16,7 +16,7 @@ namespace NsqSharp.Utils
         /// </summary>
         /// <param name="action">The method to execute.</param>
         /// <param name="threadName">The name to assign to the thread (optional).</param>
-        public static void Run(Action action, string threadName = null)
+        public static void Run(Action action, string threadName)
         {
             if (action == null)
                 throw new ArgumentNullException("action");

--- a/NsqSharp/Utils/GoFunc.cs
+++ b/NsqSharp/Utils/GoFunc.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using NsqSharp.Core;
 using NsqSharp.Utils.Loggers;
@@ -34,6 +35,7 @@ namespace NsqSharp.Utils
                                        var logger = new TraceLogger();
                                        logger.Output(LogLevel.Critical, string.Format("{0} - {1}", threadName, ex));
                                        logger.Flush();
+                                       Trace.Flush();
                                        throw;
                                    }
                                }

--- a/NsqSharp/Utils/ITcpConn.cs
+++ b/NsqSharp/Utils/ITcpConn.cs
@@ -8,16 +8,6 @@ namespace NsqSharp.Utils
     public interface ITcpConn : IConn
     {
         /// <summary>
-        /// CloseRead shuts down the reading side of the TCP connection. Most callers should just use Close.
-        /// </summary>
-        void CloseRead();
-
-        /// <summary>
-        /// CloseWrite shuts down the writing side of the TCP connection. Most callers should just use Close.
-        /// </summary>
-        void CloseWrite();
-
-        /// <summary>
         /// Gets or sets the read timeout.
         /// </summary>
         TimeSpan ReadTimeout { get; set; }

--- a/NsqSharp/Utils/TcpConn.cs
+++ b/NsqSharp/Utils/TcpConn.cs
@@ -140,31 +140,34 @@ namespace NsqSharp.Utils
                     if (_isClosed)
                         return;
 
-                    Flush();
-
                     _isClosed = true;
 
-                    ReadTimeout = TimeSpan.FromMilliseconds(10);
-                    WriteTimeout = TimeSpan.FromMilliseconds(10);
+                    try
+                    {
+                        Flush();
 
-                    _networkStream.Close();
-                    _tcpClient.Close();
+                        ReadTimeout = TimeSpan.FromMilliseconds(10);
+                        WriteTimeout = TimeSpan.FromMilliseconds(10);
+
+                        _networkStream.Close();
+                        _tcpClient.Close();
+                    }
+                    catch (SocketException)
+                    {
+                    }
+                    catch (IOException)
+                    {
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
                 }
             }
         }
 
-        public void CloseRead()
-        {
-            Close();
-        }
-
-        public void CloseWrite()
-        {
-            Close();
-        }
-
         public void Flush()
         {
+            _networkStream.Flush();
         }
     }
 }

--- a/NsqSharp/Utils/Ticker.cs
+++ b/NsqSharp/Utils/Ticker.cs
@@ -9,7 +9,7 @@ namespace NsqSharp.Utils
     /// </summary>
     public class Ticker
     {
-        private Chan<DateTime> _tickerChan = new Chan<DateTime>();
+        private readonly Chan<DateTime> _tickerChan = new Chan<DateTime>();
         private bool _stop;
 
         /// <summary>

--- a/NsqSharp/Utils/Ticker.cs
+++ b/NsqSharp/Utils/Ticker.cs
@@ -9,7 +9,7 @@ namespace NsqSharp.Utils
     /// </summary>
     public class Ticker
     {
-        private readonly Chan<DateTime> _tickerChan = new Chan<DateTime>();
+        private Chan<DateTime> _tickerChan = new Chan<DateTime>();
         private bool _stop;
 
         /// <summary>
@@ -28,19 +28,35 @@ namespace NsqSharp.Utils
                     Thread.Sleep(duration);
                     if (!_stop)
                     {
-                        _tickerChan.Send(DateTime.Now);
+                        try
+                        {
+                            _tickerChan.Send(DateTime.Now);
+                        }
+                        catch (ChannelClosedException)
+                        {
+                        }
                     }
                 }
             }, string.Format("Ticker started:{0} duration:{1}", DateTime.Now, duration));
         }
 
         /// <summary>
-        /// Stop turns off a ticker. After Stop, no more ticks will be sent. Stop does not close the channel, to prevent a
-        /// read from the channel succeeding incorrectly.
+        /// Stop turns off a ticker. After Stop, no more ticks will be sent. Stop does not close the channel,
+        /// to prevent a read from the channel succeeding incorrectly. See <see cref="Close"/>.
         /// </summary>
         public void Stop()
         {
             _stop = true;
+        }
+
+        /// <summary>
+        /// Stops the ticker and closes the channel, exiting the ticker thread. Note: after closing a channel,
+        /// all reads from the channel will return default(T). See <see cref="Stop"/>.
+        /// </summary>
+        public void Close()
+        {
+            Stop();
+            _tickerChan.Close();
         }
 
         /// <summary>

--- a/NsqSharp/Utils/WaitGroup.cs
+++ b/NsqSharp/Utils/WaitGroup.cs
@@ -7,9 +7,6 @@ namespace NsqSharp.Utils
     /// A WaitGroup waits for a collection of routines to finish. The main routine calls Add to set the number of routines to
     /// wait for. Then each of the routines runs and calls Done when finished. At the same time, Wait can be used to block until
     /// all routines have finished. See: http://golang.org/pkg/sync/#WaitGroup
-    /// 
-    /// NOTE: This is not as robust as Go's version. Go supports reusing a WaitGroup; here we're assuming Wait will only be
-    /// called once. This may change in future implementations.
     /// </summary>
     public class WaitGroup
     {


### PR DESCRIPTION
- Consumer: Fixes nsqlookupd polling hanging when nsqd connection lost (buffer channel issue)
- Consumer: Fixes intermittent graceful shutdown hang (buffer channel issue)
- Producer: Fixes transaction cleanup contention during shutdown

See #36 
