### PR TITLE
Message Finish method documentation update

### DIFF
--- a/NsqSharp/Message.cs
+++ b/NsqSharp/Message.cs
@@ -106,7 +106,7 @@ namespace NsqSharp
         }
 
         /// <summary>
-        ///     Sends a FIN command to the nsqd which sent this message, indicating the message processed successfully.
+        ///     Sends a FIN command to the nsqd which sent this message.
         /// </summary>
         public void Finish()
         {


### PR DESCRIPTION
remove "indicating the message processed successfully" from
documentation; FIN indicates we're done (success or giving up)

fixes #40

<!---
@huboard:{"custom_state":"archived"}
-->
