### PR TITLE
Producer/Consumer: log when connect to nsqd is successful

### DIFF
--- a/NsqSharp.Tests/Bus/BusRecoveryTest.cs
+++ b/NsqSharp.Tests/Bus/BusRecoveryTest.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using NsqSharp.Api;
+using NsqSharp.Bus;
+using NsqSharp.Bus.Configuration;
+using NsqSharp.Bus.Configuration.BuiltIn;
+using NsqSharp.Core;
+using NsqSharp.Tests.Bus.TestFakes;
+using NsqSharp.Tests.TestHelpers;
+using NsqSharp.Utils;
+using NsqSharp.Utils.Extensions;
+using NUnit.Framework;
+using StructureMap;
+
+namespace NsqSharp.Tests.Bus
+{
+#if !RUN_INTEGRATION_TESTS
+    [TestFixture(IgnoreReason = "NSQD Integration Test")]
+#else
+    [TestFixture]
+#endif
+    public class BusRecoveryTest
+    {
+        private static readonly NsqdHttpClient _nsqdHttpClient;
+        private static readonly NsqLookupdHttpClient _nsqLookupdHttpClient;
+
+        private static readonly WaitGroup _wg = new WaitGroup();
+        //private static bool _handlerFinished;
+
+        static BusRecoveryTest()
+        {
+            _nsqdHttpClient = new NsqdHttpClient("http://127.0.0.1:4151", TimeSpan.FromSeconds(5));
+            _nsqLookupdHttpClient = new NsqLookupdHttpClient("http://127.0.0.1:4161", TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public void TestRecoveryAfterErrProtocol()
+        {
+            string topicName = string.Format("test_busrecovery_{0}", DateTime.Now.UnixNano());
+            const string channelName = "test_busrecovery";
+
+            var container = new Container();
+
+            _nsqdHttpClient.CreateTopic(topicName);
+            _nsqLookupdHttpClient.CreateTopic(topicName);
+
+            try
+            {
+                BusService.Start(new BusConfiguration(
+                    new StructureMapObjectBuilder(container),
+                    new NewtonsoftJsonSerializer(typeof(JsonConverter).Assembly),
+                    new MessageAuditorStub(),
+                    new MessageTypeToTopicDictionary(new Dictionary<Type, string> {
+                        { typeof(TestMessage), topicName }
+                    }),
+                    new HandlerTypeToChannelDictionary(new Dictionary<Type, string> {
+                        { typeof(TestMessageHandler), channelName }
+                    }),
+                    defaultNsqLookupdHttpEndpoints: new[] { "127.0.0.1:4161" },
+                    defaultThreadsPerHandler: 1,
+                    nsqLogger: new TestConsoleLogger(),
+                    preCreateTopicsAndChannels: true,
+                    nsqConfig: new Config
+                    {
+                        LookupdPollJitter = 0,
+                        LookupdPollInterval = TimeSpan.FromSeconds(300)
+                    }
+                ));
+
+                var bus = container.GetInstance<IBus>();
+
+                Assert.Throws<ErrProtocol>(() => bus.Send(new TestMessage { Bytes = new byte[1024 * 1024 + 1] }));
+
+                bool successfulBusSend = false;
+                int i;
+                var start = DateTime.Now;
+                _wg.Add(1);
+                for (i = 0; i < 50; i++)
+                {
+                    try
+                    {
+                        bus.Send(new TestMessage
+                        {
+                            Bytes = Encoding.UTF8.GetBytes(string.Format("recovered {0}", i + 1))
+                        });
+                        successfulBusSend = true;
+                        break;
+                    }
+                    catch (Exception)
+                    {
+                        Thread.Sleep(TimeSpan.FromMilliseconds(100));
+                    }
+                }
+
+                Assert.IsTrue(successfulBusSend, "successfulBusSend");
+
+                Console.WriteLine("*** Recovered in {0} ***", DateTime.Now - start);
+
+                _wg.Wait();
+
+                var message = TestMessageHandler.LastMessage;
+                Assert.IsNotNull(message, "TestMessageHandler.LastMessage");
+                Assert.IsNotNull(message, "TestMessageHandler.LastMessage.Bytes");
+                Assert.AreEqual(Encoding.UTF8.GetString(message.Bytes), string.Format("recovered {0}", i + 1));
+            }
+            finally
+            {
+                _nsqdHttpClient.DeleteTopic(topicName);
+                _nsqLookupdHttpClient.DeleteTopic(topicName);
+            }
+        }
+
+        private class TestMessage
+        {
+            public byte[] Bytes { get; set; }
+        }
+
+        private class TestMessageHandler : IHandleMessages<TestMessage>
+        {
+            public static TestMessage LastMessage { get; set; }
+
+            public void Handle(TestMessage message)
+            {
+                LastMessage = message;
+                _wg.Done();
+            }
+        }
+    }
+}

--- a/NsqSharp.Tests/ConsumerRdyRedistributionTest.cs
+++ b/NsqSharp.Tests/ConsumerRdyRedistributionTest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using NsqSharp.Api;
-using NsqSharp.Core;
+using NsqSharp.Tests.TestHelpers;
 using NsqSharp.Tests.Utils.Extensions;
 using NsqSharp.Utils.Extensions;
 using NUnit.Framework;
@@ -163,21 +163,6 @@ namespace NsqSharp.Tests
                 _nsqdHttpClient1.DeleteTopic(topicName);
                 _nsqdHttpClient2.DeleteTopic(topicName);
                 _nsqLookupdHttpClient.DeleteTopic(topicName);
-            }
-        }
-
-        public class TestConsoleLogger : ILogger
-        {
-            /// <summary>
-            /// Writes the output for a logging event.
-            /// </summary>
-            public void Output(LogLevel logLevel, string message)
-            {
-                Console.WriteLine("[{0}] {1}", logLevel, message);
-            }
-
-            public void Flush()
-            {
             }
         }
 

--- a/NsqSharp.Tests/NsqSharp.Tests.csproj
+++ b/NsqSharp.Tests/NsqSharp.Tests.csproj
@@ -89,6 +89,7 @@
   <ItemGroup>
     <Compile Include="Bus\AutofacBusTest.cs" />
     <Compile Include="Bus\BusCurrentMessageTest.cs" />
+    <Compile Include="Bus\BusRecoveryTest.cs" />
     <Compile Include="Bus\BusShutdownTest.cs" />
     <Compile Include="Bus\CurrentThreadMessageMockableTest.cs" />
     <Compile Include="Bus\DeferTest.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="Bus\Tuple.cs" />
     <Compile Include="Bus\Utils\InterfaceBuilderTest.cs" />
     <Compile Include="ConsumerRdyRedistributionTest.cs" />
+    <Compile Include="TestHelpers\TestConsoleLogger.cs" />
     <Compile Include="Utils\Channels\ChanTest.cs" />
     <Compile Include="Core\CommandTest.cs" />
     <Compile Include="ConfigTest.cs" />

--- a/NsqSharp.Tests/TestHelpers/TestConsoleLogger.cs
+++ b/NsqSharp.Tests/TestHelpers/TestConsoleLogger.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NsqSharp.Core;
+
+namespace NsqSharp.Tests.TestHelpers
+{
+    public class TestConsoleLogger : ILogger
+    {
+        /// <summary>
+        /// Writes the output for a logging event.
+        /// </summary>
+        public void Output(LogLevel logLevel, string message)
+        {
+            Console.WriteLine("[{0}] {1}", logLevel, message);
+        }
+
+        public void Flush()
+        {
+        }
+    }
+}

--- a/NsqSharp.Tests/Utils/TimerTest.cs
+++ b/NsqSharp.Tests/Utils/TimerTest.cs
@@ -15,7 +15,7 @@ namespace NsqSharp.Tests.Utils
             bool ticked = false;
             new SelectCase()
                 .CaseReceive(timer.C, _ => ticked = true)
-                .CaseReceive(Time.After(TimeSpan.FromSeconds(2)))
+                .CaseReceive(Time.After(TimeSpan.FromSeconds(3)))
                 .NoDefault();
             Assert.IsTrue(ticked);
         }
@@ -23,7 +23,7 @@ namespace NsqSharp.Tests.Utils
         [Test]
         public void TestTimerDidNotElapse()
         {
-            var timer = new Timer(TimeSpan.FromSeconds(2));
+            var timer = new Timer(TimeSpan.FromSeconds(3));
             bool ticked = false;
             new SelectCase()
                 .CaseReceive(timer.C, _ => ticked = true)

--- a/NsqSharp/Consumer.cs
+++ b/NsqSharp/Consumer.cs
@@ -800,6 +800,8 @@ namespace NsqSharp
                 _mtx.ExitWriteLock();
             }
 
+            log(LogLevel.Info, string.Format("({0}) connected to nsqd", addr));
+
             // pre-emptive signal to existing connections to lower their RDY count
             _perConnMaxInFlightOverride = 0;
             foreach (var c in conns())

--- a/NsqSharp/Producer.cs
+++ b/NsqSharp/Producer.cs
@@ -411,14 +411,15 @@ namespace NsqSharp
                 }
                 catch (Exception ex)
                 {
-                    _conn.Close();
                     log(LogLevel.Error, string.Format("({0}) error connecting to nsqd - {1}", _addr, ex.Message));
+                    _conn.Close();
                     throw;
                 }
 
                 _state = (int)State.Connected;
                 _closeChan = new Chan<int>();
                 _wg.Add(1);
+                log(LogLevel.Info, string.Format("{0} connected to nsqd", _addr));
                 GoFunc.Run(router, string.Format("Producer:router P{0}", _id));
             }
         }


### PR DESCRIPTION
- add test for Producer recovery when E_BAD_MESSAGE forces a disconnect

closes #66
closes #68 

/cc @crazybert
