### PR TITLE
Fix bug when topic name end with #ephemeral

### DIFF
--- a/Examples/PingPong/Configuration/Mappings/HandlerTypeToChannelProvider.cs
+++ b/Examples/PingPong/Configuration/Mappings/HandlerTypeToChannelProvider.cs
@@ -16,8 +16,8 @@ namespace PingPong.Configuration.Mappings
 
         public HandlerTypeToChannelProvider()
         {
-            _handlerToChannel.Add(typeof(PingHandler), "ping-handler");
-            _handlerToChannel.Add(typeof(PongHandler), "pong-handler");
+            _handlerToChannel.Add(typeof(PingHandler), "ping-handler#ephemeral");
+            _handlerToChannel.Add(typeof(PongHandler), "pong-handler#ephemeral");
         }
 
         public string GetChannel(Type handlerType)

--- a/Examples/PingPong/Configuration/Mappings/MessageTypeToTopicProvider.cs
+++ b/Examples/PingPong/Configuration/Mappings/MessageTypeToTopicProvider.cs
@@ -13,8 +13,8 @@ namespace PingPong.Configuration.Mappings
 
         public MessageTypeToTopicProvider()
         {
-            _messageToTopic.Add(typeof(PingMessage), "pings");
-            _messageToTopic.Add(typeof(PongMessage), "pongs");
+            _messageToTopic.Add(typeof(PingMessage), "pings#ephemeral");
+            _messageToTopic.Add(typeof(PongMessage), "pongs#ephemeral");
         }
 
         public string GetTopic(Type messageType)

--- a/NsqSharp/Api/NsqHttpApi.cs
+++ b/NsqSharp/Api/NsqHttpApi.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Web;
 using NsqSharp.Core;
 
 namespace NsqSharp.Api
@@ -148,7 +149,7 @@ namespace NsqSharp.Api
                 throw new ArgumentNullException("route");
 
             route = route.TrimStart(new[] { '/' });
-
+            route = route.Replace("#", "%23");
             return string.Format("{0}/{1}", _httpAddress, route);
         }
 


### PR DESCRIPTION
There is a bug when topic name end with #ephemeral.
It occurs when communication with nsqlookupd